### PR TITLE
修复异步fire问题

### DIFF
--- a/src/onfire.js
+++ b/src/onfire.js
@@ -67,8 +67,9 @@
   **/
   function fire(eventName) {
     // fire events
+    var args = slice(arguments, 1);
     setTimeout(function () {
-      _fire_func(eventName, slice(arguments, 1));
+      _fire_func(eventName, args);
     });
   }
   /**

--- a/src/onfire.js
+++ b/src/onfire.js
@@ -67,7 +67,9 @@
   **/
   function fire(eventName) {
     // fire events
-    setTimeout(_fire_func(eventName, slice(arguments, 1)), 0);
+    setTimeout(function () {
+      _fire_func(eventName, slice(arguments, 1));
+    });
   }
   /**
    *  onfire.fireSync( event[, data1 [,data2] ... ] )


### PR DESCRIPTION
原先的fire函数在setTimeout中直接使用__fire_func()，这样并没有起到异步的效果，__fire_func()在异步前就已经执行了，setTimeout的参数应该是函数，而不是__fire_func()的执行结果。
